### PR TITLE
parse section returns a section if any areas are found. Layouts can have sections that only have static fields in them.

### DIFF
--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -59,7 +59,7 @@ export const parseViewLayout = (layout, data, key) => {
  * @returns {object} - parsed section
  */
 export const parseSection = (section, data, key) => {
-  const { layout } = section;
+  const { layout, allowStaticOnlySection } = section;
   const areas = [];
 
   layout.forEach((area, index) => {
@@ -86,7 +86,18 @@ export const parseSection = (section, data, key) => {
     }
   });
 
-  return areas.length ? { name: section.name, areas, columns: !!section.columns } : null;
+  if (allowStaticOnlySection) {
+    return areas.length ? { name: section.name, areas, columns: !!section.columns } : null;
+  }
+
+  const hasNonStaticFields = areas.some((area) => {
+    if (Array.isArray(area)) {
+      return area.some((field) => !valueExists(field.type, STATIC_TYPES));
+    }
+    return !valueExists(area.type, STATIC_TYPES);
+  });
+
+  return hasNonStaticFields ? { name: section.name, areas, columns: !!section.columns } : null;
 }
 
 /**

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -86,14 +86,7 @@ export const parseSection = (section, data, key) => {
     }
   });
 
-  const hasNonStaticFields = areas.some((area) => {
-    if (Array.isArray(area)) {
-      return area.some((field) => !valueExists(field.type, STATIC_TYPES));
-    }
-    return !valueExists(area.type, STATIC_TYPES);
-  });
-
-  return hasNonStaticFields ? { name: section.name, areas, columns: !!section.columns } : null;
+  return areas.length ? { name: section.name, areas, columns: !!section.columns } : null;
 }
 
 /**


### PR DESCRIPTION
I wanted to have a section in a config view that would just display text if the data didn't meet the criteria to show anything for that section. I saw that it wouldn't show the section at all if it only had static fields in it though.

I figured this was because conditionals didn't seem to work for static fields and thus couldn't be used to hide them, but I saw that the hideIf property could still be used to successfully hide them, so I thought perhaps we could take this restriction off now.

With this change, I can have a section that looks like this now if the information should not be displayed:

![image](https://github.com/timmonsgroup/shared-react-components/assets/149396903/9ce06bf5-e077-4928-91e6-11e772e4cf02)
