### PR TITLE
new features for view conditionals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
     'no-debugger': 'warn',
     'no-empty': 'off',
     'no-extra-semi': 'warn',
+    'curly': 'warn'
   },
 };

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     'react/no-unescaped-entities': 'off',
     'no-empty': 'off',
     'no-extra-semi': 'warn',
-    'semi': ['warn', 'always']
+    'semi': ['warn', 'always'],
+    'curly': 'warn'
   }
 };

--- a/src/src/helpers/story-helpers/ViewLayoutPreset.js
+++ b/src/src/helpers/story-helpers/ViewLayoutPreset.js
@@ -44,7 +44,7 @@ export const BIG_VIEW_PRESET = {
             label: 'Genetics Data Collected',
             path: 'geneticsDataCollected',
             type: 0,
-            defaultValue:'Don\'t need genetics'
+            defaultValue: 'Don\'t need genetics'
           },
           {
             label: 'CWD Private Lands',
@@ -165,19 +165,14 @@ export const BIG_VIEW_PRESET = {
       name: 'Valid Information',
       editable: true,
       enabled: true,
+      allowStaticOnlySection: true,
       layout: [
-        // [
-        //  {
-        //      type: 'text',
-        //      text: 'This sample record is invalid',
-        //      hidden: true,
-        //      conditions: [{
-        //          when: 'invalid',
-        //          is: true,
-        //          then: { hidden: false }
-        //      }]
-        //  }
-        // ],
+        [
+          {
+            type: 'text',
+            text: 'This sample record is invalid',
+          }
+        ],
         [
           {
             label: 'First Name',
@@ -187,7 +182,9 @@ export const BIG_VIEW_PRESET = {
             conditions: [
               {
                 when: 'sampleType',
-                is: 'Hunter Harvested',
+                exists: true,
+                // is: true,
+                // not: true,
                 then: { hidden: false },
               },
             ],
@@ -506,13 +503,6 @@ export const BIG_VIEW_PRESET = {
             type: 'component',
             component: 'EmptyField',
             hidden: true,
-            conditions: [
-              {
-                when: 'cwdSampleStatus',
-                is: 'Positive',
-                then: { hidden: false },
-              },
-            ],
           },
           {
             path: 'cwdSampleStatus',
@@ -530,7 +520,8 @@ export const BIG_VIEW_PRESET = {
           {
             label: 'Zone',
             path: 'utmZone',
-            type: 7,          },
+            type: 7,
+          },
           {
             label: 'Easting',
             path: 'utmEasting',
@@ -768,6 +759,7 @@ export const BigViewLayoutData = {
   cwdPrivateLands: 'undefined',
   dMap: 'undefined',
   meatReplacementTagRequested: 'undefined',
+  sampleType: true
 };
 
 export const ViewLayoutData = {

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -400,10 +400,10 @@ const isConditionMet = (condition, triggerData) => {
   // We follow up with (exists === false) instead of doing an else statement because we don't want the negative case to trigger
   // if exists is null or undefined
   if (exists === true || exists === 'true') {
-    conditionMet = isEmpty(triggerData);
+    conditionMet = !isEmpty(triggerData);
   }
   if (exists === false || exists === 'false') {
-    conditionMet = !isEmpty(triggerData);
+    conditionMet = isEmpty(triggerData);
   }
 
   /**
@@ -416,7 +416,7 @@ const isConditionMet = (condition, triggerData) => {
   */
   //if (value || value === false) guarentees the condition will only fail if value is undefined or null.
   //if value is false, we would still want to check if the trigger data value is a false value or not.
-  if (value || value === false) {
+  if (value || value === false || value === 0) {
     conditionMet = triggerData?.toString() === value?.toString();
   }
 

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -373,8 +373,8 @@ const getTriggerIdValue = (triggerId, data) => {
     triggerData = getViewFieldValue(triggerData);
   }
 
-  return triggerData
-}
+  return triggerData;
+};
 
 const isConditionMet = (condition, triggerData, fieldId) => {
   const { is: value, exists, not } = condition;
@@ -382,12 +382,12 @@ const isConditionMet = (condition, triggerData, fieldId) => {
   if (Object.hasOwn(condition, 'is') && Object.hasOwn(condition, 'exists')) {
     console.log(`Warning: You have provided "is" and "exist" in the field configuration for the ${fieldId} field. "is" takes precedence over "exists" inside of a conditional configuration`)
   }
-  /**  
+  /**
    * By default, if the condition is configured just as:
     {
       when: 'property',
       then: ...stuff happens
-    } 
+    }
     It should satisfy the conditional if the when property is true.
   */
   let conditionMet = !!triggerData;
@@ -438,7 +438,7 @@ const isConditionMet = (condition, triggerData, fieldId) => {
   * then: ...stuff happens
   * }
   * The conditional should be satisfied if the when property does not have a value
-  * 
+  *
   * {
   * when: 'property',
   * not: true
@@ -451,5 +451,5 @@ const isConditionMet = (condition, triggerData, fieldId) => {
     conditionMet = !conditionMet;
   }
 
-  return conditionMet
-}
+  return conditionMet;
+};

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -432,7 +432,7 @@ export const getConditionalLoadout = (field, data) => {
       * The conditional should be satisfied if the when property is not true
       */
       // Let's not rely on truthiness just in case someone thinks they're supposed to configure this with a string
-      if (not === true || true === 'true') conditionMet = !conditionMet
+      if (not === true || not === 'true') conditionMet = !conditionMet
 
       if (conditionMet) {
         props = { ...props, ...loadOut };

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -432,7 +432,7 @@ export const getConditionalLoadout = (field, data) => {
       * The conditional should be satisfied if the when property is not true
       */
       // Let's not rely on truthiness just in case someone thinks they're supposed to configure this with a string
-      if (not === true || not === 'true') conditionMet = !conditionMet
+      if (not === true || not === 'true') conditionMet = !conditionMet;
       //trigger linter
       if (conditionMet) {
         props = { ...props, ...loadOut };

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -355,14 +355,86 @@ export const getConditionalLoadout = (field, data) => {
   let props = {};
   if (conditions?.length) {
     conditions.forEach((condition) => {
-      const { when: triggerId, is: value, isValid, then: loadOut } = condition;
+      const { when: triggerId, is: value, exists, not, isValid, then: loadOut } = condition;
+
       let triggerData = data[triggerId];
+      const triggerDataIsNotEmpty = !isEmpty(triggerData)
+      if (triggerDataIsNotEmpty) triggerData = getViewFieldValue(triggerData);
 
-      if (!isEmpty(triggerData)) {
-        triggerData = getViewFieldValue(triggerData);
-      }
+      /**  
+       * By default, if the condition is configured just as:
+        {
+          when: 'property',
+          then: ...stuff happens
+        } 
+        It should satisfy the conditional if the when property is true.
+      */
+      let conditionMet = !!triggerData
 
-      if (isValid || triggerData?.toString() === value?.toString()) {
+      /**
+       * {
+       * when: 'property',
+       * exists: true,
+       * then: ...stuff happens
+       * }
+       * The conditional should be satisfied if the when property has any value
+       */
+      // We follow up with (exists === false) instead of doing an else statement because we don't want the negative case to trigger
+      // if exists is null or undefined
+      if (exists === true || exists === 'true') conditionMet = triggerDataIsNotEmpty
+      if (exists === false || exists === 'false') conditionMet = !triggerDataIsNotEmpty
+
+      /**
+      * {
+      * when: 'property',
+      * is: 5
+      * then: ...stuff happens
+      * }
+      * The conditional should be satisfied if the when property has the value of 5
+      */
+      //if (value || value === false) guarentees the condition will only fail if value is undefined or null.
+      //if value is false, we would still want to check if the trigger data value is a false value or not.
+      if (value || value === false) conditionMet = triggerData?.toString() === value?.toString()
+
+      /**
+      * {
+      * when: 'property',
+      * isValid: true
+      * then: ...stuff happens
+      * }
+      * The conditional should be satisfied automatically.
+      * If isValid: false, the conditional should fail automatically
+      */
+      if (typeof isValid === 'boolean') conditionMet = isValid
+
+      /**
+      * {
+      * when: 'property',
+      * is: 5,
+      * not: true
+      * then: ...stuff happens
+      * }
+      * The conditional should be satisfied if the when property does not have the value of 5
+      *
+      * {
+      * when: 'property',
+      * exists: true,
+      * not: true
+      * then: ...stuff happens
+      * }
+      * The conditional should be satisfied if the when property does not have a value
+      * 
+      * {
+      * when: 'property',
+      * not: true
+      * then: ...stuff happens
+      * }
+      * The conditional should be satisfied if the when property is not true
+      */
+      // Let's not rely on truthiness just in case someone thinks they're supposed to configure this with a string
+      if (not === true || true === 'true') conditionMet = !conditionMet
+
+      if (conditionMet) {
         props = { ...props, ...loadOut };
       }
     });

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -62,7 +62,7 @@ export const parseSection = (section, data, key) => {
   const { layout } = section;
   const areas = [];
 
-  layout.forEach((area, index) => {
+  layout.forEach((area) => {
     // check if the element is an array
     const areaFields = [];
     if (Array.isArray(area)) {
@@ -94,7 +94,7 @@ export const parseSection = (section, data, key) => {
   });
 
   return hasNonStaticFields ? { name: section.name, areas, columns: !!section.columns } : null;
-}
+};
 
 /**
  * Check if a value is in the object
@@ -287,7 +287,7 @@ export const getViewValue = (field, inData, empty, key) => {
   }
 
   return value;
-}
+};
 
 /**
  * Parse and set various properties for supported static fields
@@ -358,8 +358,10 @@ export const getConditionalLoadout = (field, data) => {
       const { when: triggerId, is: value, exists, not, isValid, then: loadOut } = condition;
 
       let triggerData = data[triggerId];
-      const triggerDataIsNotEmpty = !isEmpty(triggerData)
-      if (triggerDataIsNotEmpty) triggerData = getViewFieldValue(triggerData);
+      const triggerDataIsNotEmpty = !isEmpty(triggerData);
+      if (triggerDataIsNotEmpty) {
+        triggerData = getViewFieldValue(triggerData);
+      }
 
       /**  
        * By default, if the condition is configured just as:
@@ -369,7 +371,7 @@ export const getConditionalLoadout = (field, data) => {
         } 
         It should satisfy the conditional if the when property is true.
       */
-      let conditionMet = !!triggerData
+      let conditionMet = !!triggerData;
 
       /**
        * {
@@ -381,8 +383,12 @@ export const getConditionalLoadout = (field, data) => {
        */
       // We follow up with (exists === false) instead of doing an else statement because we don't want the negative case to trigger
       // if exists is null or undefined
-      if (exists === true || exists === 'true') conditionMet = triggerDataIsNotEmpty
-      if (exists === false || exists === 'false') conditionMet = !triggerDataIsNotEmpty
+      if (exists === true || exists === 'true') {
+        conditionMet = triggerDataIsNotEmpty;
+      }
+      if (exists === false || exists === 'false') {
+        conditionMet = !triggerDataIsNotEmpty;
+      }
 
       /**
       * {
@@ -394,7 +400,9 @@ export const getConditionalLoadout = (field, data) => {
       */
       //if (value || value === false) guarentees the condition will only fail if value is undefined or null.
       //if value is false, we would still want to check if the trigger data value is a false value or not.
-      if (value || value === false) conditionMet = triggerData?.toString() === value?.toString()
+      if (value || value === false) {
+        conditionMet = triggerData?.toString() === value?.toString();
+      }
 
       /**
       * {
@@ -405,7 +413,9 @@ export const getConditionalLoadout = (field, data) => {
       * The conditional should be satisfied automatically.
       * If isValid: false, the conditional should fail automatically
       */
-      if (typeof isValid === 'boolean') conditionMet = isValid
+      if (typeof isValid === 'boolean') {
+        conditionMet = isValid;
+      }
 
       /**
       * {
@@ -432,7 +442,9 @@ export const getConditionalLoadout = (field, data) => {
       * The conditional should be satisfied if the when property is not true
       */
       // Let's not rely on truthiness just in case someone thinks they're supposed to configure this with a string
-      if (not === true || not === 'true') conditionMet = !conditionMet;
+      if (not === true || not === 'true') {
+        conditionMet = !conditionMet;
+      }
       //trigger linter
       if (conditionMet) {
         props = { ...props, ...loadOut };

--- a/src/src/helpers/viewLayout.js
+++ b/src/src/helpers/viewLayout.js
@@ -433,7 +433,7 @@ export const getConditionalLoadout = (field, data) => {
       */
       // Let's not rely on truthiness just in case someone thinks they're supposed to configure this with a string
       if (not === true || not === 'true') conditionMet = !conditionMet
-
+      //trigger linter
       if (conditionMet) {
         props = { ...props, ...loadOut };
       }

--- a/src/src/stories/ConfigView.stories.jsx
+++ b/src/src/stories/ConfigView.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ConfigView } from './ConfigView';
 import { HashRouter as Router } from 'react-router-dom';
 import { parseViewLayout } from '../helpers/viewLayout';
-import { VIEW_PRESET, ViewLayoutData, BIG_VIEW_PRESET, BigViewLayoutData} from '../helpers/story-helpers/ViewLayoutPreset';
+import { VIEW_PRESET, ViewLayoutData, BIG_VIEW_PRESET, BigViewLayoutData } from '../helpers/story-helpers/ViewLayoutPreset';
 
 
 const meta = {
@@ -12,7 +12,7 @@ const meta = {
 const render = (args) => {
   const sections = parseViewLayout(args.layout, args.data);
   return <Router>
-    <ConfigView sections={sections} dynamicComponents={{}} />
+    <ConfigView sections={sections} dynamicComponents={{ EmptyField: () => { } }} />
   </Router>;
 };
 

--- a/src/src/stories/ConfigView/ConfigView.jsx
+++ b/src/src/stories/ConfigView/ConfigView.jsx
@@ -192,7 +192,7 @@ export const FieldValue = ({field}) => {
       </>
     );
   }
-  return <Typography variant="detailItem" className={className}>{field.value}</Typography>;
+  return <Typography variant="detailItem" className={className}>{field.value?.toString()}</Typography>;
 };
 
 FieldValue.propTypes = {


### PR DESCRIPTION
Added the `exists` and `not` properties to view conditional configurations.

If exists is true, the conditional will be satisfied if the `when` property has any value at all.
If exists is false, the conditional will be satisfied if the `when` property has no value.

If `not` is true, the conditional will be satisfied if it fails to meet its other conditions.
i.e.
      /**
      * {
      * when: 'property',
      * is: 5,
      * not: true
      * then: ...stuff happens
      * }
      * The conditional should be satisfied if the when property does not have the value of 5
      *
      * {
      * when: 'property',
      * exists: true,
      * not: true
      * then: ...stuff happens
      * }
      * The conditional should be satisfied if the when property does not have a value.

Changed it so that if you just put `when` and `then` in the configuration and nothing else, it defaults to checking to see if the `when` property is true or not. i.e.
  /**  
       * By default, if the condition is configured just as:
        {
          when: 'property',
          then: ...stuff happens
        } 
        It should satisfy the conditional if the when property is true.
      */

`isValid` can now be set to `false`. If `isValid` is true, the condition is automatically satisfied. If it is false, the condition automatically fails. This can still be negated by `not`

Conditions override each other. `IsValid` takes the most precedence, then `is`, then `exists`, then the default `when` only. `Not` will check the negation of whatever the overriding condition is.
